### PR TITLE
[Fix] keep the data of user changes on item detail screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:item_dex/models/product.dart';
 import 'package:item_dex/models/product_data.dart';
-import 'package:item_dex/screens/item_detail_screen.dart';
-import 'package:item_dex/screens/search_screen.dart';
-import 'package:item_dex/widgets/item_dex_text.dart';
-import 'package:item_dex/widgets/my_item_sizedbox.dart';
+import 'package:item_dex/screens/home_screen.dart';
 import 'package:provider/provider.dart';
 
 // 非同期処理のためmain関数をFutureに変更
@@ -26,60 +22,9 @@ class MainApp extends StatelessWidget {
           theme: ThemeData(
             colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
           ),
-          home: const MyHomePage(),
+          home: const HomeScreen(),
         );
       },
-    );
-  }
-}
-
-class MyHomePage extends StatelessWidget {
-  const MyHomePage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    var appState = context.watch<ProductData>();
-    final itemDexText = ItemDexText();
-
-    return Scaffold(
-      appBar: AppBar(
-        title: itemDexText.createHeaderTitle('マイアイテム'),
-      ),
-      body: ListView(
-        children: appState.myItems
-            .map((myItem) => MyItemSizedBox(
-                  hitProduct: myItem,
-                  myItemTappedCallback: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(builder: (context) {
-                        return ChangeNotifierProvider(
-                          create: (context) => HitProduct(
-                            name: myItem.name,
-                            brand: myItem.brand,
-                            image: myItem.image,
-                          ),
-                          builder: (context, child) {
-                            return const ItemDetailScreen();
-                          },
-                        );
-                      }),
-                    );
-                  },
-                ))
-            .toList(),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (context) => const SearchScreen(),
-            ),
-          );
-        },
-        child: const Icon(Icons.add),
-      ),
     );
   }
 }

--- a/lib/models/product.dart
+++ b/lib/models/product.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:uuid/uuid.dart';
 
 class Info {
   final List<HitProduct> hitProducts;
@@ -20,6 +21,7 @@ class Info {
 }
 
 class HitProduct extends ChangeNotifier {
+  final String id = const Uuid().v4();
   final String name;
   final ImageURL image;
   final Brand brand;

--- a/lib/models/product.dart
+++ b/lib/models/product.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
 
 class Info {
@@ -20,7 +19,7 @@ class Info {
   }
 }
 
-class HitProduct extends ChangeNotifier {
+class HitProduct {
   final String id = const Uuid().v4();
   final String name;
   final ImageURL image;
@@ -47,17 +46,6 @@ class HitProduct extends ChangeNotifier {
       image: ImageURL.fromJson(json['image']),
       brand: Brand.fromJson(json['brand']),
     );
-  }
-
-  void updateMyItem(
-    int? purchasePrice,
-    DateTime purchaseDate,
-    DateTime warrantyPriod,
-  ) {
-    this.purchaseDate = purchaseDate;
-    this.purchasePrice = purchasePrice;
-    this.warrantyPriod = warrantyPriod;
-    notifyListeners();
   }
 }
 

--- a/lib/models/product_data.dart
+++ b/lib/models/product_data.dart
@@ -32,13 +32,27 @@ class ProductData extends ChangeNotifier {
     notifyListeners();
   }
 
-  void updateMyItem(
-    HitProduct item,
-    int purchasePrice,
-    DateTime purchaseDate,
-    DateTime warrantyPriod,
-  ) {
-    item.updateMyItem(purchasePrice, purchaseDate, warrantyPriod);
+  // Search item by ID
+  HitProduct searchMyItemWithID(String id) {
+    return _myItems.firstWhere((item) => item.id == id);
+  }
+
+  // Update my item details
+  void updatePurchasePrice(String id, int? purchasePrice) {
+    var item = _myItems.firstWhere((item) => item.id == id);
+    item.purchasePrice = purchasePrice;
+    notifyListeners();
+  }
+
+  void updatePurchaseDate(String id, DateTime purchaseDate) {
+    var item = _myItems.firstWhere((item) => item.id == id);
+    item.purchaseDate = purchaseDate;
+    notifyListeners();
+  }
+
+  void updateWarrantyPriod(String id, DateTime warrantyPriod) {
+    var item = _myItems.firstWhere((item) => item.id == id);
+    item.warrantyPriod = warrantyPriod;
     notifyListeners();
   }
 }

--- a/lib/models/tile_type.dart
+++ b/lib/models/tile_type.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:item_dex/models/product.dart';
+import 'package:item_dex/models/product_data.dart';
 import 'package:item_dex/screens/select_date_screen.dart';
 import 'package:item_dex/screens/update_price_screen.dart';
 
 enum TileType {
   purchasePrice,
   purchaseDate,
-  warrantyPriod,
+  warrantyPriod;
 }
 
 extension TileTypeExtension on TileType {
@@ -35,7 +35,8 @@ extension TileTypeExtension on TileType {
     return DateFormat.yMMMMd().format(date); // TODO: 日本語表示に直す
   }
 
-  String getTrailingText(HitProduct item) {
+  String getTrailingText(ProductData productData, String id) {
+    var item = productData.searchMyItemWithID(id);
     switch (this) {
       case TileType.purchasePrice:
         return _priceFormatter(item.purchasePrice);
@@ -46,12 +47,13 @@ extension TileTypeExtension on TileType {
     }
   }
 
-  Widget getWidget(HitProduct item) {
+  Widget getWidget(ProductData productData, String id) {
+    var item = productData.searchMyItemWithID(id);
     switch (this) {
       case TileType.purchasePrice:
         return UpdatePriceScreen(
           onOKPressed: (price) {
-            item.updateMyItem(price, item.purchaseDate, item.warrantyPriod);
+            productData.updatePurchasePrice(id, price);
           },
         );
       case TileType.purchaseDate:
@@ -59,7 +61,7 @@ extension TileTypeExtension on TileType {
           tileType: TileType.purchaseDate,
           selectedDate: item.purchaseDate,
           onDateTimeChanged: (date) {
-            item.updateMyItem(item.purchasePrice, date, item.warrantyPriod);
+            productData.updatePurchaseDate(id, date);
           },
         );
       case TileType.warrantyPriod:
@@ -67,7 +69,7 @@ extension TileTypeExtension on TileType {
           tileType: TileType.warrantyPriod,
           selectedDate: item.warrantyPriod,
           onDateTimeChanged: (date) {
-            item.updateMyItem(item.purchasePrice, item.purchaseDate, date);
+            productData.updateWarrantyPriod(id, date);
           },
         );
     }

--- a/lib/repositories/search.dart
+++ b/lib/repositories/search.dart
@@ -1,0 +1,32 @@
+import 'dart:convert';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:http/http.dart' as http;
+import 'package:item_dex/models/product.dart';
+
+class SearchRepository {
+  Future<List<HitProduct>> searchProduct(String keyword) async {
+    // 1. http通信に必要なデータを準備をする
+    final String token = dotenv.env['YAHOO_API_APP_ID'] ?? '';
+    final uri = Uri.https(
+      'shopping.yahooapis.jp',
+      '/ShoppingWebService/V3/itemSearch',
+      {
+        'appid': token,
+        'query': keyword,
+      },
+    );
+    // 2. Yahoo APIにリクエストを送る
+    final http.Response response = await http.get(
+      uri,
+    );
+
+    if (response.statusCode == 200) {
+      final body = jsonDecode(response.body);
+      final info = Info.fromJson(body);
+      return info.hitProducts;
+    } else {
+      return []; // 200以外の場合は空のリストを返す
+    }
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:item_dex/models/product.dart';
+import 'package:item_dex/models/product_data.dart';
+import 'package:item_dex/screens/item_detail_screen.dart';
+import 'package:item_dex/screens/search_screen.dart';
+import 'package:item_dex/widgets/item_dex_text.dart';
+import 'package:item_dex/widgets/my_item_sizedbox.dart';
+import 'package:provider/provider.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    var appState = context.watch<ProductData>();
+    final itemDexText = ItemDexText();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: itemDexText.createHeaderTitle('マイアイテム'),
+      ),
+      body: ListView(
+        children: appState.myItems
+            .map((myItem) => MyItemSizedBox(
+                  hitProduct: myItem,
+                  myItemTappedCallback: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (context) {
+                        return ChangeNotifierProvider(
+                          create: (context) => HitProduct(
+                            name: myItem.name,
+                            brand: myItem.brand,
+                            image: myItem.image,
+                          ),
+                          builder: (context, child) {
+                            return const ItemDetailScreen();
+                          },
+                        );
+                      }),
+                    );
+                  },
+                ))
+            .toList(),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => const SearchScreen(),
+            ),
+          );
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:item_dex/models/product.dart';
 import 'package:item_dex/models/product_data.dart';
 import 'package:item_dex/screens/item_detail_screen.dart';
 import 'package:item_dex/screens/search_screen.dart';
@@ -27,15 +26,8 @@ class HomeScreen extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(builder: (context) {
-                        return ChangeNotifierProvider(
-                          create: (context) => HitProduct(
-                            name: myItem.name,
-                            brand: myItem.brand,
-                            image: myItem.image,
-                          ),
-                          builder: (context, child) {
-                            return const ItemDetailScreen();
-                          },
+                        return ItemDetailScreen(
+                          item: myItem,
                         );
                       }),
                     );

--- a/lib/screens/item_detail_screen.dart
+++ b/lib/screens/item_detail_screen.dart
@@ -3,88 +3,97 @@ import 'package:item_dex/models/product.dart';
 import 'package:item_dex/models/tile_type.dart';
 import 'package:item_dex/widgets/item_dex_text.dart';
 import 'package:item_dex/widgets/my_item_detail_listtile.dart';
-import 'package:provider/provider.dart';
 
 class ItemDetailScreen extends StatelessWidget {
-  const ItemDetailScreen({super.key});
+  final HitProduct item;
+  const ItemDetailScreen({
+    super.key,
+    required this.item,
+  });
 
   @override
   Widget build(BuildContext context) {
     final itemDexText = ItemDexText();
-
-    return Consumer<HitProduct>(builder: (context, item, child) {
-      return Scaffold(
-        appBar: AppBar(
-          title: itemDexText.createHeaderTitle('アイテム詳細'),
-        ),
-        body: ListView(
-          children: [
-            Column(
-              children: [
-                Container(
-                  color: Theme.of(context).colorScheme.primaryContainer,
-                  padding: const EdgeInsets.all(4),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    crossAxisAlignment: CrossAxisAlignment.end,
-                    children: [
-                      // Textを改行して表示
-                      Flexible(
-                        child: Text(
-                          item.name,
-                          maxLines: 3,
-                          overflow: TextOverflow.ellipsis,
-                          style: const TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ),
-                      const SizedBox(width: 8),
-                      Text(
-                        item.brand.name,
+    return Scaffold(
+      appBar: AppBar(
+        title: itemDexText.createHeaderTitle('アイテム詳細'),
+      ),
+      body: ListView(
+        children: [
+          Column(
+            children: [
+              Container(
+                color: Theme.of(context).colorScheme.primaryContainer,
+                padding: const EdgeInsets.all(4),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    // Textを改行して表示
+                    Flexible(
+                      child: Text(
+                        item.name,
                         maxLines: 3,
                         overflow: TextOverflow.ellipsis,
                         style: const TextStyle(
                           fontSize: 16,
+                          fontWeight: FontWeight.bold,
                         ),
                       ),
-                    ],
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: SizedBox(
-                    height: 150,
-                    width: 150,
-                    child: Image.network(item.image.medium),
-                  ),
-                ),
-              ],
-            ),
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Container(
-                  width: double.infinity, // 横幅いっぱいに広げる
-                  color: Theme.of(context).colorScheme.primaryContainer,
-                  padding: const EdgeInsets.all(4),
-                  child: const Text(
-                    'ユーザー入力欄',
-                    style: TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.bold,
                     ),
+                    const SizedBox(width: 8),
+                    Text(
+                      item.brand.name,
+                      maxLines: 3,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontSize: 16,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: SizedBox(
+                  height: 150,
+                  width: 150,
+                  child: Image.network(item.image.medium),
+                ),
+              ),
+            ],
+          ),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: double.infinity, // 横幅いっぱいに広げる
+                color: Theme.of(context).colorScheme.primaryContainer,
+                padding: const EdgeInsets.all(4),
+                child: const Text(
+                  'ユーザー入力欄',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
                   ),
                 ),
-                const MyItemDetailListTile(tileType: TileType.purchasePrice),
-                const MyItemDetailListTile(tileType: TileType.purchaseDate),
-                const MyItemDetailListTile(tileType: TileType.warrantyPriod),
-              ],
-            )
-          ],
-        ),
-      );
-    });
+              ),
+              MyItemDetailListTile(
+                tileType: TileType.purchasePrice,
+                itemID: item.id,
+              ),
+              MyItemDetailListTile(
+                tileType: TileType.purchaseDate,
+                itemID: item.id,
+              ),
+              MyItemDetailListTile(
+                tileType: TileType.warrantyPriod,
+                itemID: item.id,
+              ),
+            ],
+          )
+        ],
+      ),
+    );
   }
 }

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -1,10 +1,6 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:http/http.dart' as http; // httpという変数を通して、httpパッケージにアクセス
-import 'package:item_dex/models/product.dart'; // 作成したモデル
 import 'package:item_dex/models/product_data.dart';
+import 'package:item_dex/repositories/search.dart';
 import 'package:item_dex/widgets/item_dex_text.dart';
 import 'package:item_dex/widgets/product_sizedbox.dart';
 import 'package:provider/provider.dart';
@@ -40,7 +36,8 @@ class SearchScreen extends StatelessWidget {
                     icon: Icon(Icons.search),
                   ),
                   onSubmitted: (String value) async {
-                    final result = await searchProduct(value);
+                    final result =
+                        await SearchRepository().searchProduct(value);
                     productData.updateProductsSearchResult(result);
                   },
                 ),
@@ -64,30 +61,5 @@ class SearchScreen extends StatelessWidget {
         );
       },
     );
-  }
-
-  Future<List<HitProduct>> searchProduct(String keyword) async {
-    // 1. http通信に必要なデータを準備をする
-    final String token = dotenv.env['YAHOO_API_APP_ID'] ?? '';
-    final uri = Uri.https(
-      'shopping.yahooapis.jp',
-      '/ShoppingWebService/V3/itemSearch',
-      {
-        'appid': token,
-        'query': keyword,
-      },
-    );
-    // 2. Yahoo APIにリクエストを送る
-    final http.Response response = await http.get(
-      uri,
-    );
-
-    if (response.statusCode == 200) {
-      final body = jsonDecode(response.body);
-      final info = Info.fromJson(body);
-      return info.hitProducts;
-    } else {
-      return []; // 200以外の場合は空のリストを返す
-    }
   }
 }

--- a/lib/widgets/my_item_detail_listtile.dart
+++ b/lib/widgets/my_item_detail_listtile.dart
@@ -1,46 +1,46 @@
 import 'package:flutter/material.dart';
-import 'package:item_dex/models/product.dart';
+import 'package:item_dex/models/product_data.dart';
 import 'package:item_dex/models/tile_type.dart';
 import 'package:provider/provider.dart';
 
 class MyItemDetailListTile extends StatelessWidget {
   final TileType tileType;
+  final String itemID;
   const MyItemDetailListTile({
     super.key,
     required this.tileType,
+    required this.itemID,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Consumer<HitProduct>(
-      builder: (context, item, child) {
-        return ListTile(
-          shape: Border(
-            bottom: BorderSide(
-              color: Theme.of(context).dividerColor,
-              width: 1,
-            ),
-          ),
-          leading: Text(
-            tileType.title,
-            style: const TextStyle(
-              fontSize: 16,
-            ),
-          ),
-          trailing: Text(
-            tileType.getTrailingText(item),
-            style: const TextStyle(
-              fontSize: 16,
-            ),
-          ),
-          onTap: () {
-            // ハーフモーダル
-            showModalBottomSheet(
-              context: context,
-              builder: (context) {
-                return tileType.getWidget(item);
-              },
-            );
+    var appState = context.watch<ProductData>();
+
+    return ListTile(
+      shape: Border(
+        bottom: BorderSide(
+          color: Theme.of(context).dividerColor,
+          width: 1,
+        ),
+      ),
+      leading: Text(
+        tileType.title,
+        style: const TextStyle(
+          fontSize: 16,
+        ),
+      ),
+      trailing: Text(
+        tileType.getTrailingText(appState, itemID),
+        style: const TextStyle(
+          fontSize: 16,
+        ),
+      ),
+      onTap: () {
+        // ハーフモーダル
+        showModalBottomSheet(
+          context: context,
+          builder: (context) {
+            return tileType.getWidget(appState, itemID);
           },
         );
       },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.2"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
   fake_async:
     dependency: transitive
     description:
@@ -184,6 +192,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   stack_trace:
     dependency: transitive
     description:
@@ -232,6 +248,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  uuid:
+    dependency: "direct main"
+    description:
+      name: uuid
+      sha256: e03928880bdbcbf496fb415573f5ab7b1ea99b9b04f669c01104d085893c3134
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   provider: ^6.0.5
   rflutter_alert: ^2.0.7
   scroll_date_picker: ^3.7.3
+  uuid: ^4.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## What I did in this PR
- Divide the files and refactoring
  - Create HomeScreen file
  - Create SearchRepository file
- Add uuid package for specifying the HitProduct data
- Remove the extend of ChangeNotifier in HitProduct class

-> Those changes allow my app to retain user change data on item detail screen!

## Screenshot

https://github.com/Juliennu/Flutter_ItemDex/assets/76898162/4ebce1dd-d869-4d0f-95d0-6a9f79e8c1bc

